### PR TITLE
Add snippet support for HTML language

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
             {
                 "language": "css",
                 "path": "./snippets/svelte-style.json"
+            },
+            {
+                "language": "html",
+                "path": "./snippets/svelte.json"
             }
         ]
     },


### PR DESCRIPTION
People might be interested to associate HTML language to .svelte files instead of creating a new Svelte language. Those people then needs the svelte snippets to be associated with HTML language.