### PR TITLE
Add s-script-ts

### DIFF
--- a/snippets/svelte.json
+++ b/snippets/svelte.json
@@ -23,6 +23,15 @@
         ],
         "description": "add a script to your svelte file"
     },
+    "svelte-script-tag": {
+        "prefix": "s-script-ts",
+        "body": [
+            "<script lang=\"ts\">",
+            "\t${1:// your script goes here}",
+            "</script>"
+        ],
+        "description": "add a script with lang=\"ts\" to your svelte file"
+    },
     "svelte-script-context": {
         "prefix": "s-script-context",
         "body": [


### PR DESCRIPTION
adds a `s-script-ts` snippet which creates the following code:
```html
<script lang="ts">,
  // your script goes here,
</script>"
```

**Edit:**
It looks like, this repo isn’t maintained anymore, I’ll probably upload my fork to the VSCode Marketplace